### PR TITLE
chore: add typescript and react in prod dependancies for build for CF

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "dependencies": {
     "@headlessui/react": "^2.1.2",
     "@heroicons/react": "^2.1.5",
+    "@types/node": "20.14.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
     "autoprefixer": "^10.4.19",
     "classnames": "^2.5.1",
     "cssnano": "^7.0.4",
@@ -21,20 +24,16 @@
     "next": "^14.2.5",
     "next-sitemap": "^4.2.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
-  },
-  "devDependencies": {
+    "react-dom": "^18.3.1",
+    "typescript": "^5.5.4",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.13",
-    "@types/node": "20.14.12",
-    "@types/react": "^18.3.3",
     "eslint": "^9.7.0",
     "postcss": "^8.4.40",
     "postcss-preset-env": "^9.6.0",
     "prettier": "^3.3.3",
     "sass": "^1.77.8",
-    "tailwindcss": "^3.4.6",
-    "typescript": "^5.5.4"
+    "tailwindcss": "^3.4.6"
   },
   "resolutions": {
     "string-width": "^5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,7 +665,14 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.12.tgz#12bb1e2be27293c1406acb6af1c3f3a1481d98c6"
   integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
 
-"@types/react@^18.3.3":
+"@types/react-dom@^18.3.0":
+  version "18.3.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
+  integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^18.3.3":
   version "18.3.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
   integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==


### PR DESCRIPTION
Weird commit
If we want to use NODE_ENV=production ; Cloudflare doesn't get it. so everything should go into dependencies.